### PR TITLE
Editorial (E3): differentiate duplicate capabilities-response headings

### DIFF
--- a/draft-ietf-netconf-https-notif-cbor.md
+++ b/draft-ietf-netconf-https-notif-cbor.md
@@ -124,7 +124,7 @@ GET /some/path/capabilities HTTP/1.1
 
  If the receiver is able to reply using “application/yang-data+cbor” and assuming it is only capable of receiving CBOR encoded messages the response would look like this
 
-### CBOR using names as keys
+### CBOR using names as keys (receiver accepts CBOR only)
 
 ~~~ http-message
    HTTP/1.1 200 OK
@@ -162,7 +162,7 @@ A1                                      # map(1)
 
 If the receiver is able to reply using “application/yang-data+cbor” and assuming it is not capable of receiving cbor, but can receive both json and xml notifications:
 
-### CBOR using names as keys
+### CBOR using names as keys (receiver accepts JSON and XML)
 
 ~~~ http-message
    HTTP/1.1 200 OK


### PR DESCRIPTION
Both subsections were titled 'CBOR using names as keys'; qualify each by the receiver's accepted encodings.